### PR TITLE
#3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog for aws-serverless-retry
-<!--LATEST=3.3.2-->
+<!--LATEST=3.3.3-->
 <!--ENTRYINSERT-->
+
+#3.3.3
+* feature: SNSService.sendToTopic --> Added the ability to set message attributes so that messages can be filtered by the attribute. To receive only a subset
+ of the messages, a subscriber will need to assign filter policy to the topic subscription.
 
 ## 3.3.2
 * bugfix: sqsService.processMessage renamed hasPoisedMessage to hasPoisonMessage

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ SNS Service:
     ```
 
     
-- sendToTopic(topicName, payload, subject, phoneNumber)
+- sendToTopic(topicName, payload, subject, phoneNumber, attributes)
 
-    Publishes payload to specified topic. If topic does't exists it creates topic and then sends payload to that topic
+    Publishes payload to specified topic. If topic doesn't exists it creates topic and then sends payload to that topic
     
     Response: Promise aws-sdk standard publishTopic response with additional topicName property
     ```javascript
@@ -148,7 +148,11 @@ SNS Service:
     // Subjects must be ASCII text that begins with a letter, number, or punctuation mark; must not include line breaks 
     // or control characters; and must be less than 100 characters long
     //phoneNumber: Optional parameter. The phone number to which you want to deliver an SMS message
-    snsService.sendToTopic("topicName", payload, subject, phoneNumber)
+    //attributes: Optional parameter. JSON object only. Sets the message attributes of the message so that the messages can be filtered by the attribute.
+    //    example, attributes: { "subscriberEmail": "subscriber1@email.com" }. If the topic subscriber assigns filter policy for 'subscriberEmail' attribute and
+    //    the attribute matches, then the subscriber receives the message.
+
+    snsService.sendToTopic("topicName", payload, subject, phoneNumber, attributes)
                 .then(response => {
                     //Success
                     //response is standard aws-sdk response with additional topicName property

--- a/lib/snsService.js
+++ b/lib/snsService.js
@@ -92,12 +92,15 @@ SNSService.prototype.sendToTopicByStatusCode = function (statusCode, payload, sn
     }
 };
 
-SNSService.prototype.sendToTopic = function (topicName, payload, subject, phoneNumber) {
+SNSService.prototype.sendToTopic = function (topicName, payload, subject, phoneNumber, attributes) {
     Util.log("INFO", "Sending to topic " + topicName);
     return this.createTopic(topicName)
         .then(response => {
             return new Promise((resolve, reject) => {
-                let params = {Message: JSON.stringify(payload)};
+                let params = {
+                    Message: JSON.stringify(payload),
+                    MessageAttributes: {}
+                };
                 params.TopicArn = response.TopicArn;
 
                 if (subject){
@@ -105,6 +108,16 @@ SNSService.prototype.sendToTopic = function (topicName, payload, subject, phoneN
                 }
                 if (phoneNumber){
                     params.PhoneNumber = phoneNumber;
+                }
+
+                // Accepts only string type message attribute value
+                if (attributes && typeof attributes === 'object'){
+                    _.each(Object.keys(attributes), function(key){
+                        params.MessageAttributes[key] = {
+                            'DataType': 'String',
+                            'StringValue': attributes[key]
+                        };
+                    });
                 }
 
                 this.SNS.publish(params, function (err, data) {

--- a/lib/snsService.js
+++ b/lib/snsService.js
@@ -51,7 +51,7 @@ SNSService.prototype.createTopic = function (topicName) {
     });
 };
 
-SNSService.prototype.sendToTopicByStatusCode = function (statusCode, payload, snsConfig, subject) {
+SNSService.prototype.sendToTopicByStatusCode = function (statusCode, payload, snsConfig, subject, phoneNumber, attributes) {
 
     Util.log("INFO", "Sending it to topic by statusCode " + statusCode);
     if (!statusCode) {
@@ -82,13 +82,13 @@ SNSService.prototype.sendToTopicByStatusCode = function (statusCode, payload, sn
     let retryCount = message.retryCount || message.retrycount;
     if (this.isRetryStatusCode(snsConfig.retryStatusCodes, statusCode) && (!retryCount || retryCount <= snsConfig.maxRetryAttempts)) {
         message = this.incrementRetryCount(message);
-        return this.sendToTopic(snsConfig.retryTopicName, message, subject);
+        return this.sendToTopic(snsConfig.retryTopicName, message, subject, phoneNumber, attributes);
     } else if (this.isFailureStatusCode(snsConfig.failureStatusCodes, statusCode)) {
-        return this.sendToTopic(snsConfig.failureTopicName, message, subject);
+        return this.sendToTopic(snsConfig.failureTopicName, message, subject, phoneNumber, attributes);
     } else if (this.isSuccessStatusCode(snsConfig.successStatusCodes, statusCode)) {
-        return this.sendToTopic(snsConfig.successTopicName, message, subject);
+        return this.sendToTopic(snsConfig.successTopicName, message, subject, phoneNumber, attributes);
     } else {
-        return this.sendToTopic(snsConfig.failureTopicName, message, subject);
+        return this.sendToTopic(snsConfig.failureTopicName, message, subject, phoneNumber, attributes);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-serverless-retry",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Simple library to retry or poll your payload using SNS, SQS and Lambda",
   "main": "index.js",
   "scripts": {

--- a/test/testSendToTopicByStatusCode.js
+++ b/test/testSendToTopicByStatusCode.js
@@ -32,6 +32,40 @@ module.exports.sendToTopicByStatusCodeTests = {
                 test.done();
             });
     },
+    testToSendItToSuccessTopicWithMessageAttributesOn200: function (test) {
+        let config = {
+            retryStatusCodes: [],
+            failureStatusCodes: [],
+            successStatusCodes: [200],
+            maxRetryAttempts: 2,
+            retryTopicName: "retry-topic",
+            successTopicName: "success-topic",
+            failureTopicName: "error-topic"
+        };
+
+        let snsService = new SNSService("us-west-2");
+        let statusCode = 200;
+        let subject = "Test Subject - Message Filtering";
+        let phoneNumber = '';
+        let attributes = {
+            "country": "subscriber-country",
+            "city": "subscriber-city"
+        };
+        let payload = {
+            "data": "Test"
+        };
+
+        snsService.sendToTopicByStatusCode(statusCode, payload, config, subject, phoneNumber, attributes)
+            .then(response => {
+                test.ok(response !== null);
+                test.ok(response.topicName === config.successTopicName);
+                test.done();
+            })
+            .catch(err => {
+                //Only used by build server
+                test.done();
+            });
+    },
     testToSendItToErrorTopicOn400: function (test) {
         let config = {
             retryStatusCodes: [],


### PR DESCRIPTION
* feature: SNSService.sendToTopic --> Added the ability to set message attributes so that messages can be filtered by attribute(s). To receive only a subset
 of the messages, a subscriber will need to assign filter policy to the topic subscription.